### PR TITLE
Parameterize variables so these can be set on the playbook schedule

### DIFF
--- a/M365HealthStatus.ps1
+++ b/M365HealthStatus.ps1
@@ -30,13 +30,31 @@
   https://github.com/einast/PS_M365_scripts
 #>
 
-# User defined variables
-$ApplicationID = 'application ID'
-$ApplicationKey = 'application key'
-$TenantDomain = 'your FQDN' # Alternatively use DirectoryID if tenant domain fails
-$URI = 'Teams webhook URI'
+param (
+    # Your AppID
+    [Parameter(Mandatory=$True)]
+    [string]
+    $ApplicationID,
+    # Your Application Key
+    [Parameter(Mandatory=$True)]
+    [string]
+    $ApplicationKey,
+    # Your AAD Tenant Domain
+    [Parameter(Mandatory=$True)]
+    [string]
+    $TenantDomain,
+    # Your Teams Webhook URL
+    [Parameter(Mandatory=$True)]
+    [string]
+    $URI,
+    # Minutes between runs. Make sure to align this with your schedule
+    [Parameter()]
+    [int]
+    $Minutes = 15
+)
+
+# Get the current time
 $Now = Get-Date
-$Minutes = '15'
 
 # Request data
 $body = @{


### PR DESCRIPTION
Parameterize all user configurable variables so they can easily and "securely" be set in the schedule for the playbook.
![bilde](https://user-images.githubusercontent.com/5641179/67936134-803e2500-fbcb-11e9-90aa-2a6c3d2f5839.png)
